### PR TITLE
Improve service and handler tests

### DIFF
--- a/routes/user_routes.go
+++ b/routes/user_routes.go
@@ -7,10 +7,10 @@ import (
 )
 
 func SetupUserRoutes(r *gin.Engine) {
-	users := r.Group("/user")
+	users := r.Group("/users")
 	users.GET("/", middleware.JWTAuthMiddleware(), handlers.GetAllUsersHandler)
 	users.GET("/me", middleware.JWTAuthMiddleware(), handlers.MeHandler)
 	users.POST("/", middleware.JWTAuthMiddleware(), handlers.CreateUserHandler)
-	users.GET("/:id", handlers.GetUserByIDHandler)
+	users.GET("/:id", middleware.JWTAuthMiddleware(), handlers.GetUserByIDHandler)
 	users.DELETE("/:id", middleware.JWTAuthMiddleware(), handlers.DeleteUserHandler)
 }

--- a/tests/handlers/auth_handler_test.go
+++ b/tests/handlers/auth_handler_test.go
@@ -3,19 +3,21 @@ package handlers_test
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/Ulpio/reservas-cipt/dto"
 	"github.com/Ulpio/reservas-cipt/services"
+	"github.com/Ulpio/reservas-cipt/tests"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestLoginHandler(t *testing.T) {
+	tests.SetupTestDB(t)
+
 	// cria um usuário para login
-	createdUser, _ := services.CreateUser("Login Test", "00011122233", "admin")
+	_, _ = services.CreateUser("Login Test", "00011122233", "admin")
 
 	router := setupTestRouter()
 	login := dto.LoginInputDTO{CPF: "00011122233", Password: "12345678"}
@@ -23,7 +25,6 @@ func TestLoginHandler(t *testing.T) {
 
 	req, _ := http.NewRequest(http.MethodPost, "/auth/login", bytes.NewBuffer(jsonLogin))
 	req.Header.Set("Content-Type", "application/json")
-	fmt.Println("Criando usuário:", createdUser)
 
 	resp := httptest.NewRecorder()
 	router.ServeHTTP(resp, req)

--- a/tests/handlers/user_handler_test.go
+++ b/tests/handlers/user_handler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Ulpio/reservas-cipt/dto"
 	"github.com/Ulpio/reservas-cipt/routes"
 	"github.com/Ulpio/reservas-cipt/services"
+	"github.com/Ulpio/reservas-cipt/tests"
 	"github.com/Ulpio/reservas-cipt/utils"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -25,6 +26,11 @@ func setupTestRouter() *gin.Engine {
 }
 
 func TestCreateUserHandler(t *testing.T) {
+	tests.SetupTestDB(t)
+
+	admin, _ := services.CreateUser("Admin", "00000000000", "admin")
+	token, _ := utils.GenerateJWT(admin.ID, admin.Role)
+
 	router := setupTestRouter()
 
 	body := dto.UserInputDTO{
@@ -32,8 +38,9 @@ func TestCreateUserHandler(t *testing.T) {
 	}
 	jsonBody, _ := json.Marshal(body)
 
-	req, _ := http.NewRequest(http.MethodPost, "/users", bytes.NewBuffer(jsonBody))
+	req, _ := http.NewRequest(http.MethodPost, "/users/", bytes.NewBuffer(jsonBody))
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
 
 	resp := httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
@@ -42,6 +49,8 @@ func TestCreateUserHandler(t *testing.T) {
 }
 
 func TestGetUserByIDHandler(t *testing.T) {
+	tests.SetupTestDB(t)
+
 	user, _ := services.CreateUser("Me User", "22233344455", "admin")
 	token, _ := utils.GenerateJWT(user.ID, user.Role)
 
@@ -52,14 +61,20 @@ func TestGetUserByIDHandler(t *testing.T) {
 	router.ServeHTTP(resp, req)
 
 	assert.Equal(t, http.StatusOK, resp.Code)
-	assert.Contains(t, resp.Body.String(), "Handler Test")
+	assert.Contains(t, resp.Body.String(), "Me User")
 }
 
 func TestDeleteUserHandler(t *testing.T) {
+	tests.SetupTestDB(t)
+
+	admin, _ := services.CreateUser("Admin", "11122233344", "admin")
+	token, _ := utils.GenerateJWT(admin.ID, admin.Role)
+
 	user, _ := services.CreateUser("To Delete", "99988877766", "admin")
 
 	router := setupTestRouter()
 	req, _ := http.NewRequest(http.MethodDelete, "/users/"+strconv.Itoa(int(user.ID)), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	resp := httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
 
@@ -67,12 +82,14 @@ func TestDeleteUserHandler(t *testing.T) {
 }
 
 func TestMeHandler(t *testing.T) {
+	tests.SetupTestDB(t)
+
 	// cria usuário e obtém token
 	user, _ := services.CreateUser("Me User", "22233344455", "admin")
 	token, _ := utils.GenerateJWT(user.ID, user.Role)
 
 	router := setupTestRouter()
-	req, _ := http.NewRequest(http.MethodGet, "/me", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/users/me", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 
 	resp := httptest.NewRecorder()

--- a/tests/services/user_service_test.go
+++ b/tests/services/user_service_test.go
@@ -3,28 +3,13 @@ package services_test
 import (
 	"testing"
 
-	"github.com/Ulpio/reservas-cipt/database"
-	"github.com/Ulpio/reservas-cipt/models"
 	"github.com/Ulpio/reservas-cipt/services"
+	"github.com/Ulpio/reservas-cipt/tests"
 	"github.com/stretchr/testify/assert"
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
 )
 
-func setupTestDB(t *testing.T) *gorm.DB {
-	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
-	assert.NoError(t, err)
-
-	err = db.AutoMigrate(&models.User{})
-	assert.NoError(t, err)
-
-	database.DB = db
-
-	return db
-}
-
 func TestCreateAndGetUser(t *testing.T) {
-	setupTestDB(t)
+	tests.SetupTestDB(t)
 
 	// Cria o usuário
 	created, err := services.CreateUser("Alice", "12345678900", "admin")
@@ -39,7 +24,7 @@ func TestCreateAndGetUser(t *testing.T) {
 }
 
 func TestGetAllUsers(t *testing.T) {
-	setupTestDB(t)
+	tests.SetupTestDB(t)
 
 	// Cria múltiplos usuários
 	_, _ = services.CreateUser("User 1", "11111111111", "admin")
@@ -51,7 +36,7 @@ func TestGetAllUsers(t *testing.T) {
 }
 
 func TestDeleteUser(t *testing.T) {
-	setupTestDB(t)
+	tests.SetupTestDB(t)
 
 	u, _ := services.CreateUser("Temp", "99999999999", "admin")
 

--- a/tests/setup.go
+++ b/tests/setup.go
@@ -1,0 +1,29 @@
+package tests
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Ulpio/reservas-cipt/database"
+	"github.com/Ulpio/reservas-cipt/models"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func SetupTestDB(t *testing.T) *gorm.DB {
+	os.Setenv("JWT_SECRET", "testsecret")
+
+	dsn := fmt.Sprintf("file:%d?mode=memory&cache=shared", time.Now().UnixNano())
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	assert.NoError(t, err)
+
+	err = db.AutoMigrate(&models.User{})
+	assert.NoError(t, err)
+
+	database.DB = db
+
+	return db
+}


### PR DESCRIPTION
## Summary
- add in-memory DB setup helper and JWT secret for tests
- tighten user routes and require authentication on all endpoints
- expand service and handler tests with proper token handling

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689bb1a508088324a788d13ce5a071cb