### PR TITLE
feat: add client strike management

### DIFF
--- a/database/postgres.go
+++ b/database/postgres.go
@@ -34,5 +34,5 @@ func ConnectDB() {
 }
 
 func MigrateModels() {
-	DB.AutoMigrate(&models.User{}, &models.Client{}, &models.Space{}, &models.Reservation{})
+	DB.AutoMigrate(&models.User{}, &models.Client{}, &models.Space{}, &models.Reservation{}, &models.Strike{})
 }

--- a/dto/strike_dto.go
+++ b/dto/strike_dto.go
@@ -1,0 +1,19 @@
+package dto
+
+import "time"
+
+type StrikeInputDTO struct {
+	ClientID uint   `json:"client_id" binding:"required"`
+	Reason   string `json:"reason" binding:"required"`
+	Photo    string `json:"photo"`
+}
+
+type StrikeOutputDTO struct {
+	ID        uint       `json:"id"`
+	ClientID  uint       `json:"client_id"`
+	Reason    string     `json:"reason"`
+	Photo     string     `json:"photo"`
+	CreatedAt time.Time  `json:"created_at"`
+	Revoked   bool       `json:"revoked"`
+	RevokedAt *time.Time `json:"revoked_at"`
+}

--- a/handlers/strike_handlers.go
+++ b/handlers/strike_handlers.go
@@ -1,0 +1,69 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/Ulpio/reservas-cipt/dto"
+	"github.com/Ulpio/reservas-cipt/services"
+	"github.com/gin-gonic/gin"
+)
+
+func CreateStrikeHandler(c *gin.Context) {
+	role := c.GetString("role")
+	if role != "admin" && role != "recepcionista" {
+		c.JSON(http.StatusForbidden, gin.H{"message": "você não tem autorização para adicionar strikes"})
+		return
+	}
+	var input dto.StrikeInputDTO
+	if err := c.ShouldBindJSON(&input); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "input inválido"})
+		return
+	}
+	strike, err := services.CreateStrike(input)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err})
+		return
+	}
+	c.JSON(http.StatusCreated, strike)
+}
+
+func GetStrikesByClientHandler(c *gin.Context) {
+	role := c.GetString("role")
+	if role != "admin" && role != "recepcionista" {
+		c.JSON(http.StatusForbidden, gin.H{"message": "você não tem autorização para listar os strikes"})
+		return
+	}
+	id := c.Param("id")
+	clientID, err := strconv.Atoi(id)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "id invalido"})
+		return
+	}
+	strikes, err := services.GetStrikesByClient(uint(clientID))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err})
+		return
+	}
+	c.JSON(http.StatusOK, strikes)
+}
+
+func RevokeStrikeHandler(c *gin.Context) {
+	role := c.GetString("role")
+	if role != "admin" {
+		c.JSON(http.StatusForbidden, gin.H{"message": "você não tem autorização para revogar strikes"})
+		return
+	}
+	id := c.Param("id")
+	strikeID, err := strconv.Atoi(id)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "id invalido"})
+		return
+	}
+	strike, err := services.RevokeStrike(uint(strikeID))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err})
+		return
+	}
+	c.JSON(http.StatusOK, strike)
+}

--- a/models/strike.go
+++ b/models/strike.go
@@ -1,0 +1,16 @@
+package models
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+type Strike struct {
+	gorm.Model
+	ClientID  uint
+	Reason    string `gorm:"not null"`
+	Photo     string
+	Revoked   bool
+	RevokedAt *time.Time
+}

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -9,5 +9,6 @@ func SetupRoutes() {
 	SpaceRoutes(r)
 	SetupClientRoutes(r)
 	SetupReservationRoutes(r)
+	SetupStrikeRoutes(r)
 	r.Run(":8080")
 }

--- a/routes/strike_routes.go
+++ b/routes/strike_routes.go
@@ -1,0 +1,17 @@
+package routes
+
+import (
+	"github.com/Ulpio/reservas-cipt/handlers"
+	"github.com/Ulpio/reservas-cipt/middleware"
+	"github.com/gin-gonic/gin"
+)
+
+func SetupStrikeRoutes(r *gin.Engine) {
+	grupo := r.Group("/strikes")
+	grupo.Use(middleware.JWTAuthMiddleware())
+	{
+		grupo.POST("/", handlers.CreateStrikeHandler)
+		grupo.GET("/client/:id", handlers.GetStrikesByClientHandler)
+		grupo.DELETE("/:id", handlers.RevokeStrikeHandler)
+	}
+}

--- a/services/strike_services.go
+++ b/services/strike_services.go
@@ -1,0 +1,76 @@
+package services
+
+import (
+	"time"
+
+	"github.com/Ulpio/reservas-cipt/database"
+	"github.com/Ulpio/reservas-cipt/dto"
+	"github.com/Ulpio/reservas-cipt/models"
+)
+
+func CreateStrike(input dto.StrikeInputDTO) (dto.StrikeOutputDTO, error) {
+	strike := models.Strike{
+		ClientID: input.ClientID,
+		Reason:   input.Reason,
+		Photo:    input.Photo,
+	}
+	if err := database.DB.Create(&strike).Error; err != nil {
+		return dto.StrikeOutputDTO{}, err
+	}
+	if err := updateClientStrikeCount(strike.ClientID); err != nil {
+		return dto.StrikeOutputDTO{}, err
+	}
+	return toStrikeOutput(strike), nil
+}
+
+func GetStrikesByClient(clientID uint) ([]dto.StrikeOutputDTO, error) {
+	var strikes []models.Strike
+	if err := database.DB.Where("client_id = ?", clientID).Find(&strikes).Error; err != nil {
+		return nil, err
+	}
+	var output []dto.StrikeOutputDTO
+	for _, s := range strikes {
+		output = append(output, toStrikeOutput(s))
+	}
+	return output, nil
+}
+
+func RevokeStrike(id uint) (dto.StrikeOutputDTO, error) {
+	var strike models.Strike
+	if err := database.DB.First(&strike, id).Error; err != nil {
+		return dto.StrikeOutputDTO{}, err
+	}
+	if strike.Revoked {
+		return toStrikeOutput(strike), nil
+	}
+	now := time.Now()
+	strike.Revoked = true
+	strike.RevokedAt = &now
+	if err := database.DB.Save(&strike).Error; err != nil {
+		return dto.StrikeOutputDTO{}, err
+	}
+	if err := updateClientStrikeCount(strike.ClientID); err != nil {
+		return dto.StrikeOutputDTO{}, err
+	}
+	return toStrikeOutput(strike), nil
+}
+
+func toStrikeOutput(s models.Strike) dto.StrikeOutputDTO {
+	return dto.StrikeOutputDTO{
+		ID:        s.ID,
+		ClientID:  s.ClientID,
+		Reason:    s.Reason,
+		Photo:     s.Photo,
+		CreatedAt: s.CreatedAt,
+		Revoked:   s.Revoked,
+		RevokedAt: s.RevokedAt,
+	}
+}
+
+func updateClientStrikeCount(clientID uint) error {
+	var count int64
+	if err := database.DB.Model(&models.Strike{}).Where("client_id = ? AND revoked = ?", clientID, false).Count(&count).Error; err != nil {
+		return err
+	}
+	return database.DB.Model(&models.Client{}).Where("id = ?", clientID).Update("strikes", int(count)).Error
+}


### PR DESCRIPTION
## Summary
- add Strike model and migrations
- implement services and handlers for creating, listing, and revoking client strikes
- register strike routes
- ensure client strike count reflects active strike records

## Testing
- `timeout 15 go test ./tests/...`


------
https://chatgpt.com/codex/tasks/task_e_68aa52ef5d748324b21fa118b7b46aec