### PR TITLE
docs: expand swagger coverage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,16 @@ module github.com/Ulpio/reservas-cipt
 go 1.24.6
 
 require (
-	github.com/gin-gonic/gin v1.10.1
-	github.com/golang-jwt/jwt/v5 v5.3.0
-	github.com/joho/godotenv v1.5.1
-	github.com/stretchr/testify v1.10.0
-	golang.org/x/crypto v0.41.0
-	gorm.io/driver/postgres v1.6.0
-	gorm.io/driver/sqlite v1.6.0
-	gorm.io/gorm v1.30.1
+        github.com/gin-gonic/gin v1.10.1
+        github.com/golang-jwt/jwt/v5 v5.3.0
+        github.com/joho/godotenv v1.5.1
+       github.com/swaggo/files v1.0.1
+       github.com/swaggo/gin-swagger v1.8.3
+        github.com/stretchr/testify v1.10.0
+        golang.org/x/crypto v0.41.0
+        gorm.io/driver/postgres v1.6.0
+        gorm.io/driver/sqlite v1.6.0
+        gorm.io/gorm v1.30.1
 )
 
 require (

--- a/handlers/auth_handlers.go
+++ b/handlers/auth_handlers.go
@@ -8,6 +8,17 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// LoginHandler autentica um usuário e retorna um token JWT.
+// @Summary Autentica um usuário
+// @Description Endpoint público utilizado para autenticar usuários do sistema.
+// @Tags auth
+// @Accept json
+// @Produce json
+// @Param input body dto.LoginInputDTO true "Credenciais de acesso"
+// @Success 200 {object} map[string]string
+// @Failure 400 {object} gin.H
+// @Failure 401 {object} gin.H
+// @Router /auth/login [post]
 func LoginHandler(c *gin.Context) {
 	var input dto.LoginInputDTO
 	if err := c.ShouldBindJSON(&input); err != nil {

--- a/handlers/client_handlers.go
+++ b/handlers/client_handlers.go
@@ -9,6 +9,17 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// BuscarOuCriarClienteHandler busca um cliente pelo CPF ou cria um novo.
+// @Summary Busca ou cria cliente
+// @Description Procura um cliente pelo CPF e cria caso não exista.
+// @Tags clientes
+// @Accept json
+// @Produce json
+// @Param input body dto.ClienteInputDTO true "Dados do cliente"
+// @Success 200 {object} dto.ClienteOutputDTO
+// @Failure 400 {object} gin.H
+// @Failure 500 {object} gin.H
+// @Router /clientes/buscar-criar [post]
 func BuscarOuCriarClienteHandler(c *gin.Context) {
 	var input dto.ClienteInputDTO
 	if err := c.ShouldBindJSON(&input); err != nil {
@@ -25,6 +36,15 @@ func BuscarOuCriarClienteHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, cliente)
 }
 
+// BuscarClientePorCPF retorna os dados de um cliente a partir do CPF.
+// @Summary Busca cliente por CPF
+// @Description Retorna os dados de um cliente existente identificado pelo CPF.
+// @Tags clientes
+// @Produce json
+// @Param cpf path string true "CPF do cliente"
+// @Success 200 {object} dto.ClienteOutputDTO
+// @Failure 404 {object} gin.H
+// @Router /clientes/{cpf} [get]
 func BuscarClientePorCPF(c *gin.Context) {
 	cpf := c.Param("cpf")
 	cliente, err := services.GetClientByCPF(cpf)
@@ -35,6 +55,14 @@ func BuscarClientePorCPF(c *gin.Context) {
 	c.JSON(http.StatusOK, cliente)
 }
 
+// GetAllClientes lista todos os clientes cadastrados.
+// @Summary Lista clientes
+// @Description Retorna todos os clientes registrados.
+// @Tags clientes
+// @Produce json
+// @Success 200 {array} dto.ClienteOutputDTO
+// @Failure 500 {object} gin.H
+// @Router /clientes [get]
 func GetAllClientes(c *gin.Context) {
 	clientes, err := services.GetAllClientes()
 	if err != nil {
@@ -44,6 +72,18 @@ func GetAllClientes(c *gin.Context) {
 	c.JSON(http.StatusOK, clientes)
 }
 
+// UpdateClientHandler atualiza os dados de um cliente.
+// @Summary Atualiza cliente
+// @Description Atualiza informações de um cliente existente.
+// @Tags clientes
+// @Accept json
+// @Produce json
+// @Param id path int true "ID do cliente"
+// @Param input body dto.ClienteInputDTO true "Novos dados do cliente"
+// @Success 200 {object} dto.ClienteOutputDTO
+// @Failure 400 {object} gin.H
+// @Failure 500 {object} gin.H
+// @Router /clientes/{id} [patch]
 func UpdateClientHandler(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {

--- a/handlers/reservation_handlers.go
+++ b/handlers/reservation_handlers.go
@@ -9,7 +9,17 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// CreateReservationHandler handles the creation of a reservation.
+// CreateReservationHandler registra uma nova reserva.
+// @Summary Cria reserva
+// @Description Cria uma nova reserva para um espaço.
+// @Tags reservas
+// @Accept json
+// @Produce json
+// @Param input body dto.CreateReservationDTO true "Dados da reserva"
+// @Success 201 {object} dto.ReservationOutputDTO
+// @Failure 400 {object} gin.H
+// @Failure 500 {object} gin.H
+// @Router /reservas [post]
 func CreateReservationHandler(c *gin.Context) {
 	var input dto.CreateReservationDTO
 	if err := c.ShouldBindJSON(&input); err != nil {
@@ -26,7 +36,16 @@ func CreateReservationHandler(c *gin.Context) {
 	c.JSON(http.StatusCreated, reservation)
 }
 
-// GetReservationByIDHandler returns a reservation by its ID.
+// GetReservationByIDHandler retorna uma reserva pelo ID.
+// @Summary Busca reserva por ID
+// @Description Retorna os dados de uma reserva específica.
+// @Tags reservas
+// @Produce json
+// @Param id path int true "ID da reserva"
+// @Success 200 {object} dto.ReservationOutputDTO
+// @Failure 400 {object} gin.H
+// @Failure 404 {object} gin.H
+// @Router /reservas/{id} [get]
 func GetReservationByIDHandler(c *gin.Context) {
 	idParam := c.Param("id")
 	id, err := strconv.Atoi(idParam)
@@ -44,7 +63,14 @@ func GetReservationByIDHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, reservation)
 }
 
-// GetAllReservationsHandler lists all reservations.
+// GetAllReservationsHandler lista todas as reservas.
+// @Summary Lista reservas
+// @Description Lista todas as reservas cadastradas.
+// @Tags reservas
+// @Produce json
+// @Success 200 {array} dto.ReservationOutputDTO
+// @Failure 500 {object} gin.H
+// @Router /reservas [get]
 func GetAllReservationsHandler(c *gin.Context) {
 	reservations, err := services.GetAllReservations()
 	if err != nil {

--- a/handlers/space_handlers.go
+++ b/handlers/space_handlers.go
@@ -9,6 +9,17 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// CreateSpaceHandler cria um novo espaço disponível para reserva.
+// @Summary Cria um novo espaço físico
+// @Description Endpoint utilizado por administradores para cadastrar um novo espaço disponível para reserva.
+// @Tags espacos
+// @Accept json
+// @Produce json
+// @Param input body dto.CreateSpaceDTO true "Dados do espaço a ser criado"
+// @Success 201 {object} dto.SpaceOutputDTO
+// @Failure 400 {object} gin.H
+// @Failure 401 {object} gin.H
+// @Router /espacos [post]
 func CreateSpaceHandler(c *gin.Context) {
 	var input dto.CreateSpaceDTO
 	if err := c.ShouldBindJSON(&input); err != nil {
@@ -24,6 +35,14 @@ func CreateSpaceHandler(c *gin.Context) {
 	c.JSON(http.StatusCreated, space)
 }
 
+// GetAllSpacesHandler lista todos os espaços cadastrados.
+// @Summary Lista espaços
+// @Description Retorna todos os espaços registrados.
+// @Tags espacos
+// @Produce json
+// @Success 200 {array} dto.SpaceOutputDTO
+// @Failure 500 {object} gin.H
+// @Router /espacos [get]
 func GetAllSpacesHandler(c *gin.Context) {
 	spaces, err := services.GetAllSpaces()
 	if err != nil {
@@ -33,6 +52,17 @@ func GetAllSpacesHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, spaces)
 }
 
+// GetSpacesByIDHandler retorna um espaço específico pelo ID.
+// @Summary Busca espaço por ID
+// @Description Obtém os dados de um espaço a partir do seu identificador.
+// @Tags espacos
+// @Produce json
+// @Param id path int true "ID do espaço"
+// @Success 200 {object} dto.SpaceOutputDTO
+// @Failure 400 {object} gin.H
+// @Failure 404 {object} gin.H
+// @Failure 500 {object} gin.H
+// @Router /espacos/{id} [get]
 func GetSpacesByIDHandler(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
@@ -51,6 +81,18 @@ func GetSpacesByIDHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, sala)
 }
 
+// UpdateSpaceHandler atualiza todos os campos de um espaço.
+// @Summary Atualiza espaço
+// @Description Atualiza as informações completas de um espaço existente.
+// @Tags espacos
+// @Accept json
+// @Produce json
+// @Param id path int true "ID do espaço"
+// @Param input body dto.UpdateSpaceDTO true "Novos dados do espaço"
+// @Success 200 {object} dto.SpaceOutputDTO
+// @Failure 400 {object} gin.H
+// @Failure 500 {object} gin.H
+// @Router /espacos/{id} [put]
 func UpdateSpaceHandler(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
@@ -73,6 +115,15 @@ func UpdateSpaceHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, updated)
 }
 
+// DeleteSpaceHandler exclui um espaço do sistema.
+// @Summary Exclui espaço
+// @Description Remove um espaço previamente cadastrado.
+// @Tags espacos
+// @Param id path int true "ID do espaço"
+// @Success 204 {object} nil
+// @Failure 400 {object} gin.H
+// @Failure 500 {object} gin.H
+// @Router /espacos/{id} [delete]
 func DeleteSpaceHandler(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
@@ -88,6 +139,18 @@ func DeleteSpaceHandler(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
+// UpdateSpaceStatusHandler atualiza apenas o status de um espaço.
+// @Summary Atualiza status do espaço
+// @Description Altera o status operacional de um espaço.
+// @Tags espacos
+// @Accept json
+// @Produce json
+// @Param id path int true "ID do espaço"
+// @Param input body dto.UpdateStatusDTO true "Novo status"
+// @Success 200 {object} gin.H
+// @Failure 400 {object} gin.H
+// @Failure 500 {object} gin.H
+// @Router /espacos/{id}/status [patch]
 func UpdateSpaceStatusHandler(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
@@ -109,6 +172,18 @@ func UpdateSpaceStatusHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "Status atualizado com sucesso"})
 }
 
+// UpdateSpaceNoticeHandler atualiza apenas o aviso de um espaço.
+// @Summary Atualiza aviso do espaço
+// @Description Modifica o aviso exibido para um espaço.
+// @Tags espacos
+// @Accept json
+// @Produce json
+// @Param id path int true "ID do espaço"
+// @Param input body dto.UpdateNoticeDTO true "Novo aviso"
+// @Success 200 {object} gin.H
+// @Failure 400 {object} gin.H
+// @Failure 500 {object} gin.H
+// @Router /espacos/{id}/aviso [patch]
 func UpdateSpaceNoticeHandler(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {

--- a/handlers/strike_handlers.go
+++ b/handlers/strike_handlers.go
@@ -9,6 +9,18 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// CreateStrikeHandler registra um novo strike para um cliente.
+// @Summary Registra strike
+// @Description Cria uma advertência para um cliente.
+// @Tags strikes
+// @Accept json
+// @Produce json
+// @Param input body dto.StrikeInputDTO true "Dados do strike"
+// @Success 201 {object} dto.StrikeOutputDTO
+// @Failure 400 {object} gin.H
+// @Failure 403 {object} gin.H
+// @Failure 500 {object} gin.H
+// @Router /strikes [post]
 func CreateStrikeHandler(c *gin.Context) {
 	role := c.GetString("role")
 	if role != "admin" && role != "recepcionista" {
@@ -28,6 +40,17 @@ func CreateStrikeHandler(c *gin.Context) {
 	c.JSON(http.StatusCreated, strike)
 }
 
+// GetStrikesByClientHandler lista os strikes de um cliente.
+// @Summary Lista strikes por cliente
+// @Description Retorna as advertências associadas a um cliente específico.
+// @Tags strikes
+// @Produce json
+// @Param id path int true "ID do cliente"
+// @Success 200 {array} dto.StrikeOutputDTO
+// @Failure 400 {object} gin.H
+// @Failure 403 {object} gin.H
+// @Failure 500 {object} gin.H
+// @Router /strikes/client/{id} [get]
 func GetStrikesByClientHandler(c *gin.Context) {
 	role := c.GetString("role")
 	if role != "admin" && role != "recepcionista" {
@@ -48,6 +71,16 @@ func GetStrikesByClientHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, strikes)
 }
 
+// RevokeStrikeHandler revoga um strike existente.
+// @Summary Revoga strike
+// @Description Revoga uma advertência de um cliente.
+// @Tags strikes
+// @Param id path int true "ID do strike"
+// @Success 200 {object} dto.StrikeOutputDTO
+// @Failure 400 {object} gin.H
+// @Failure 403 {object} gin.H
+// @Failure 500 {object} gin.H
+// @Router /strikes/{id} [delete]
 func RevokeStrikeHandler(c *gin.Context) {
 	role := c.GetString("role")
 	if role != "admin" {

--- a/handlers/user_handlers.go
+++ b/handlers/user_handlers.go
@@ -9,6 +9,15 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// GetAllUsersHandler lista todos os usuários cadastrados.
+// @Summary Lista usuários
+// @Description Endpoint restrito a administradores para listagem de usuários.
+// @Tags usuarios
+// @Produce json
+// @Success 200 {array} dto.UserOutputDTO
+// @Failure 403 {object} gin.H
+// @Failure 500 {object} gin.H
+// @Router /users [get]
 func GetAllUsersHandler(c *gin.Context) {
 	role := c.GetString("role")
 	if role != "admin" {
@@ -23,6 +32,16 @@ func GetAllUsersHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, users)
 }
 
+// GetUserByIDHandler retorna um usuário específico pelo ID.
+// @Summary Busca usuário por ID
+// @Description Recupera os dados de um usuário específico.
+// @Tags usuarios
+// @Produce json
+// @Param id path int true "ID do usuário"
+// @Success 200 {object} dto.UserOutputDTO
+// @Failure 403 {object} gin.H
+// @Failure 404 {object} gin.H
+// @Router /users/{id} [get]
 func GetUserByIDHandler(c *gin.Context) {
 	role := c.GetString("role")
 	if role != "admin" {
@@ -43,6 +62,18 @@ func GetUserByIDHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, users)
 }
 
+// CreateUserHandler cria um novo usuário administrador ou recepcionista.
+// @Summary Cria usuário
+// @Description Endpoint restrito a administradores para cadastro de novos usuários.
+// @Tags usuarios
+// @Accept json
+// @Produce json
+// @Param input body dto.UserInputDTO true "Dados do usuário"
+// @Success 201 {object} dto.UserOutputDTO
+// @Failure 400 {object} gin.H
+// @Failure 403 {object} gin.H
+// @Failure 500 {object} gin.H
+// @Router /users [post]
 func CreateUserHandler(c *gin.Context) {
 	role := c.GetString("role")
 	if role != "admin" {
@@ -62,6 +93,15 @@ func CreateUserHandler(c *gin.Context) {
 	c.JSON(http.StatusCreated, newUser)
 }
 
+// DeleteUserHandler remove um usuário existente.
+// @Summary Remove usuário
+// @Description Exclui um usuário existente.
+// @Tags usuarios
+// @Param id path int true "ID do usuário"
+// @Success 204 {object} nil
+// @Failure 403 {object} gin.H
+// @Failure 500 {object} gin.H
+// @Router /users/{id} [delete]
 func DeleteUserHandler(c *gin.Context) {
 	role := c.GetString("role")
 	if role != "admin" {
@@ -82,6 +122,14 @@ func DeleteUserHandler(c *gin.Context) {
 	c.JSON(http.StatusNoContent, nil)
 }
 
+// MeHandler retorna os dados do usuário autenticado.
+// @Summary Retorna usuário autenticado
+// @Description Recupera informações do usuário baseado no token de autenticação.
+// @Tags usuarios
+// @Produce json
+// @Success 200 {object} dto.UserOutputDTO
+// @Failure 401 {object} gin.H
+// @Router /users/me [get]
 func MeHandler(c *gin.Context) {
 	userIDInterface, exists := c.Get("userID")
 	if !exists {

--- a/main.go
+++ b/main.go
@@ -1,3 +1,12 @@
+// @title Reserva de Espaços - CIPT Jaraguá
+// @version 1.0
+// @description API interna para gestão de reservas e controle de espaços físicos no Centro de Inovação do Polo Tecnológico - Jaraguá, Maceió.
+// @contact.name Ulpio Netto
+// @contact.email oxetech.mcz@gmail.com
+// @license.name MIT
+// @license.url https://opensource.org/licenses/MIT
+// @host localhost:8080
+// @BasePath /api/v1
 package main
 
 import (

--- a/routes/auth_routes.go
+++ b/routes/auth_routes.go
@@ -5,7 +5,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func SetupAuthRoutes(r *gin.Engine) {
+func SetupAuthRoutes(r *gin.RouterGroup) {
 	auth := r.Group("/auth")
 	auth.POST("/login", handlers.LoginHandler)
 }

--- a/routes/client_routes.go
+++ b/routes/client_routes.go
@@ -6,13 +6,13 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func SetupClientRoutes(r *gin.Engine) {
+func SetupClientRoutes(r *gin.RouterGroup) {
 	grupo := r.Group("/clientes")
 	grupo.Use(middleware.JWTAuthMiddleware())
 	{
 		grupo.PATCH("/:id", handlers.UpdateClientHandler)
 		grupo.GET("/:cpf", handlers.BuscarClientePorCPF)
 		grupo.POST("/buscar-criar", handlers.BuscarOuCriarClienteHandler)
-		grupo.GET("/", handlers.GetAllClientes)
+		grupo.GET("", handlers.GetAllClientes)
 	}
 }

--- a/routes/reservation_routes.go
+++ b/routes/reservation_routes.go
@@ -7,12 +7,12 @@ import (
 )
 
 // SetupReservationRoutes configures routes for reservation operations.
-func SetupReservationRoutes(r *gin.Engine) {
+func SetupReservationRoutes(r *gin.RouterGroup) {
 	group := r.Group("/reservas")
 	group.Use(middleware.JWTAuthMiddleware(), middleware.OnlyReceptionist())
 	{
-		group.POST("/", handlers.CreateReservationHandler)
-		group.GET("/", handlers.GetAllReservationsHandler)
+		group.POST("", handlers.CreateReservationHandler)
+		group.GET("", handlers.GetAllReservationsHandler)
 		group.GET("/:id", handlers.GetReservationByIDHandler)
 	}
 }

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -1,14 +1,23 @@
 package routes
 
-import "github.com/gin-gonic/gin"
+import (
+	"github.com/gin-gonic/gin"
+	swaggerFiles "github.com/swaggo/files"
+	ginSwagger "github.com/swaggo/gin-swagger"
+)
 
 func SetupRoutes() {
 	r := gin.Default()
-	SetupUserRoutes(r)
-	SetupAuthRoutes(r)
-	SpaceRoutes(r)
-	SetupClientRoutes(r)
-	SetupReservationRoutes(r)
-	SetupStrikeRoutes(r)
+
+	r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
+
+	api := r.Group("/api/v1")
+	SetupAuthRoutes(api)
+	SetupUserRoutes(api)
+	SpaceRoutes(api)
+	SetupClientRoutes(api)
+	SetupReservationRoutes(api)
+	SetupStrikeRoutes(api)
+
 	r.Run(":8080")
 }

--- a/routes/space_routes.go
+++ b/routes/space_routes.go
@@ -6,19 +6,19 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func SpaceRoutes(r *gin.Engine) {
+func SpaceRoutes(r *gin.RouterGroup) {
 	spaceGroup := r.Group("/espacos")
 	spaceGroup.Use(middleware.JWTAuthMiddleware())
 
-	spaceGroup.GET("/", handlers.GetAllSpacesHandler)
+	spaceGroup.GET("", handlers.GetAllSpacesHandler)
 	spaceGroup.GET("/:id", handlers.GetSpacesByIDHandler)
 
 	spaceGroup.PATCH("/:id/status", handlers.UpdateSpaceStatusHandler)
 	spaceGroup.PATCH("/:id/aviso", handlers.UpdateSpaceNoticeHandler)
 
-	admin := spaceGroup.Group("/")
+	admin := spaceGroup.Group("")
 	admin.Use(middleware.OnlyAdmin())
-	admin.POST("/", handlers.CreateSpaceHandler)
+	admin.POST("", handlers.CreateSpaceHandler)
 	admin.PUT("/:id", handlers.UpdateSpaceHandler)
 	admin.DELETE("/:id", handlers.DeleteSpaceHandler)
 }

--- a/routes/strike_routes.go
+++ b/routes/strike_routes.go
@@ -6,11 +6,11 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func SetupStrikeRoutes(r *gin.Engine) {
+func SetupStrikeRoutes(r *gin.RouterGroup) {
 	grupo := r.Group("/strikes")
 	grupo.Use(middleware.JWTAuthMiddleware())
 	{
-		grupo.POST("/", handlers.CreateStrikeHandler)
+		grupo.POST("", handlers.CreateStrikeHandler)
 		grupo.GET("/client/:id", handlers.GetStrikesByClientHandler)
 		grupo.DELETE("/:id", handlers.RevokeStrikeHandler)
 	}

--- a/routes/user_routes.go
+++ b/routes/user_routes.go
@@ -6,12 +6,12 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func SetupUserRoutes(r *gin.Engine) {
+func SetupUserRoutes(r *gin.RouterGroup) {
 	users := r.Group("/users")
 	users.Use(middleware.JWTAuthMiddleware())
-	users.GET("/", middleware.OnlyAdmin(), handlers.GetAllUsersHandler)
+	users.GET("", middleware.OnlyAdmin(), handlers.GetAllUsersHandler)
 	users.GET("/me", handlers.MeHandler)
-	users.POST("/", middleware.OnlyAdmin(), handlers.CreateUserHandler)
+	users.POST("", middleware.OnlyAdmin(), handlers.CreateUserHandler)
 	users.GET("/:id", handlers.GetUserByIDHandler)
 	users.DELETE("/:id", middleware.OnlyAdmin(), handlers.DeleteUserHandler)
 }


### PR DESCRIPTION
## Summary
- group routes under `/api/v1` and expose swagger UI
- document client, reservation, strike and additional user handlers with Swaggo tags

## Testing
- `go mod tidy` *(fails: forbidden while fetching modules)*
- `go test ./...` *(fails: forbidden while fetching modules)*

------
https://chatgpt.com/codex/tasks/task_e_68ab840f168483248276c554c8130aad