### PR TITLE
docs: replace gin.H in swagger annotations

### DIFF
--- a/dto/error_response.go
+++ b/dto/error_response.go
@@ -1,0 +1,5 @@
+package dto
+
+type ErrorResponse struct {
+	Error string `json:"error"`
+}

--- a/dto/message_response.go
+++ b/dto/message_response.go
@@ -1,0 +1,5 @@
+package dto
+
+type MessageResponse struct {
+	Message string `json:"message"`
+}

--- a/handlers/auth_handlers.go
+++ b/handlers/auth_handlers.go
@@ -16,8 +16,8 @@ import (
 // @Produce json
 // @Param input body dto.LoginInputDTO true "Credenciais de acesso"
 // @Success 200 {object} map[string]string
-// @Failure 400 {object} gin.H
-// @Failure 401 {object} gin.H
+// @Failure 400 {object} dto.ErrorResponse
+// @Failure 401 {object} dto.ErrorResponse
 // @Router /auth/login [post]
 func LoginHandler(c *gin.Context) {
 	var input dto.LoginInputDTO

--- a/handlers/client_handlers.go
+++ b/handlers/client_handlers.go
@@ -17,8 +17,8 @@ import (
 // @Produce json
 // @Param input body dto.ClienteInputDTO true "Dados do cliente"
 // @Success 200 {object} dto.ClienteOutputDTO
-// @Failure 400 {object} gin.H
-// @Failure 500 {object} gin.H
+// @Failure 400 {object} dto.ErrorResponse
+// @Failure 500 {object} dto.ErrorResponse
 // @Router /clientes/buscar-criar [post]
 func BuscarOuCriarClienteHandler(c *gin.Context) {
 	var input dto.ClienteInputDTO
@@ -43,7 +43,7 @@ func BuscarOuCriarClienteHandler(c *gin.Context) {
 // @Produce json
 // @Param cpf path string true "CPF do cliente"
 // @Success 200 {object} dto.ClienteOutputDTO
-// @Failure 404 {object} gin.H
+// @Failure 404 {object} dto.ErrorResponse
 // @Router /clientes/{cpf} [get]
 func BuscarClientePorCPF(c *gin.Context) {
 	cpf := c.Param("cpf")
@@ -61,7 +61,7 @@ func BuscarClientePorCPF(c *gin.Context) {
 // @Tags clientes
 // @Produce json
 // @Success 200 {array} dto.ClienteOutputDTO
-// @Failure 500 {object} gin.H
+// @Failure 500 {object} dto.ErrorResponse
 // @Router /clientes [get]
 func GetAllClientes(c *gin.Context) {
 	clientes, err := services.GetAllClientes()
@@ -81,8 +81,8 @@ func GetAllClientes(c *gin.Context) {
 // @Param id path int true "ID do cliente"
 // @Param input body dto.ClienteInputDTO true "Novos dados do cliente"
 // @Success 200 {object} dto.ClienteOutputDTO
-// @Failure 400 {object} gin.H
-// @Failure 500 {object} gin.H
+// @Failure 400 {object} dto.ErrorResponse
+// @Failure 500 {object} dto.ErrorResponse
 // @Router /clientes/{id} [patch]
 func UpdateClientHandler(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("id"))

--- a/handlers/reservation_handlers.go
+++ b/handlers/reservation_handlers.go
@@ -17,8 +17,8 @@ import (
 // @Produce json
 // @Param input body dto.CreateReservationDTO true "Dados da reserva"
 // @Success 201 {object} dto.ReservationOutputDTO
-// @Failure 400 {object} gin.H
-// @Failure 500 {object} gin.H
+// @Failure 400 {object} dto.ErrorResponse
+// @Failure 500 {object} dto.ErrorResponse
 // @Router /reservas [post]
 func CreateReservationHandler(c *gin.Context) {
 	var input dto.CreateReservationDTO
@@ -43,8 +43,8 @@ func CreateReservationHandler(c *gin.Context) {
 // @Produce json
 // @Param id path int true "ID da reserva"
 // @Success 200 {object} dto.ReservationOutputDTO
-// @Failure 400 {object} gin.H
-// @Failure 404 {object} gin.H
+// @Failure 400 {object} dto.ErrorResponse
+// @Failure 404 {object} dto.ErrorResponse
 // @Router /reservas/{id} [get]
 func GetReservationByIDHandler(c *gin.Context) {
 	idParam := c.Param("id")
@@ -69,7 +69,7 @@ func GetReservationByIDHandler(c *gin.Context) {
 // @Tags reservas
 // @Produce json
 // @Success 200 {array} dto.ReservationOutputDTO
-// @Failure 500 {object} gin.H
+// @Failure 500 {object} dto.ErrorResponse
 // @Router /reservas [get]
 func GetAllReservationsHandler(c *gin.Context) {
 	reservations, err := services.GetAllReservations()

--- a/handlers/space_handlers.go
+++ b/handlers/space_handlers.go
@@ -17,8 +17,8 @@ import (
 // @Produce json
 // @Param input body dto.CreateSpaceDTO true "Dados do espaço a ser criado"
 // @Success 201 {object} dto.SpaceOutputDTO
-// @Failure 400 {object} gin.H
-// @Failure 401 {object} gin.H
+// @Failure 400 {object} dto.ErrorResponse
+// @Failure 401 {object} dto.ErrorResponse
 // @Router /espacos [post]
 func CreateSpaceHandler(c *gin.Context) {
 	var input dto.CreateSpaceDTO
@@ -41,7 +41,7 @@ func CreateSpaceHandler(c *gin.Context) {
 // @Tags espacos
 // @Produce json
 // @Success 200 {array} dto.SpaceOutputDTO
-// @Failure 500 {object} gin.H
+// @Failure 500 {object} dto.ErrorResponse
 // @Router /espacos [get]
 func GetAllSpacesHandler(c *gin.Context) {
 	spaces, err := services.GetAllSpaces()
@@ -59,9 +59,9 @@ func GetAllSpacesHandler(c *gin.Context) {
 // @Produce json
 // @Param id path int true "ID do espaço"
 // @Success 200 {object} dto.SpaceOutputDTO
-// @Failure 400 {object} gin.H
-// @Failure 404 {object} gin.H
-// @Failure 500 {object} gin.H
+// @Failure 400 {object} dto.ErrorResponse
+// @Failure 404 {object} dto.ErrorResponse
+// @Failure 500 {object} dto.ErrorResponse
 // @Router /espacos/{id} [get]
 func GetSpacesByIDHandler(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("id"))
@@ -90,8 +90,8 @@ func GetSpacesByIDHandler(c *gin.Context) {
 // @Param id path int true "ID do espaço"
 // @Param input body dto.UpdateSpaceDTO true "Novos dados do espaço"
 // @Success 200 {object} dto.SpaceOutputDTO
-// @Failure 400 {object} gin.H
-// @Failure 500 {object} gin.H
+// @Failure 400 {object} dto.ErrorResponse
+// @Failure 500 {object} dto.ErrorResponse
 // @Router /espacos/{id} [put]
 func UpdateSpaceHandler(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("id"))
@@ -121,8 +121,8 @@ func UpdateSpaceHandler(c *gin.Context) {
 // @Tags espacos
 // @Param id path int true "ID do espaço"
 // @Success 204 {object} nil
-// @Failure 400 {object} gin.H
-// @Failure 500 {object} gin.H
+// @Failure 400 {object} dto.ErrorResponse
+// @Failure 500 {object} dto.ErrorResponse
 // @Router /espacos/{id} [delete]
 func DeleteSpaceHandler(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("id"))
@@ -147,9 +147,9 @@ func DeleteSpaceHandler(c *gin.Context) {
 // @Produce json
 // @Param id path int true "ID do espaço"
 // @Param input body dto.UpdateStatusDTO true "Novo status"
-// @Success 200 {object} gin.H
-// @Failure 400 {object} gin.H
-// @Failure 500 {object} gin.H
+// @Success 200 {object} dto.MessageResponse
+// @Failure 400 {object} dto.ErrorResponse
+// @Failure 500 {object} dto.ErrorResponse
 // @Router /espacos/{id}/status [patch]
 func UpdateSpaceStatusHandler(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("id"))
@@ -169,7 +169,7 @@ func UpdateSpaceStatusHandler(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "Status atualizado com sucesso"})
+	c.JSON(http.StatusOK, dto.MessageResponse{Message: "Status atualizado com sucesso"})
 }
 
 // UpdateSpaceNoticeHandler atualiza apenas o aviso de um espaço.
@@ -180,9 +180,9 @@ func UpdateSpaceStatusHandler(c *gin.Context) {
 // @Produce json
 // @Param id path int true "ID do espaço"
 // @Param input body dto.UpdateNoticeDTO true "Novo aviso"
-// @Success 200 {object} gin.H
-// @Failure 400 {object} gin.H
-// @Failure 500 {object} gin.H
+// @Success 200 {object} dto.MessageResponse
+// @Failure 400 {object} dto.ErrorResponse
+// @Failure 500 {object} dto.ErrorResponse
 // @Router /espacos/{id}/aviso [patch]
 func UpdateSpaceNoticeHandler(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("id"))
@@ -202,5 +202,5 @@ func UpdateSpaceNoticeHandler(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "Aviso atualizado com sucesso"})
+	c.JSON(http.StatusOK, dto.MessageResponse{Message: "Aviso atualizado com sucesso"})
 }

--- a/handlers/strike_handlers.go
+++ b/handlers/strike_handlers.go
@@ -17,9 +17,9 @@ import (
 // @Produce json
 // @Param input body dto.StrikeInputDTO true "Dados do strike"
 // @Success 201 {object} dto.StrikeOutputDTO
-// @Failure 400 {object} gin.H
-// @Failure 403 {object} gin.H
-// @Failure 500 {object} gin.H
+// @Failure 400 {object} dto.ErrorResponse
+// @Failure 403 {object} dto.ErrorResponse
+// @Failure 500 {object} dto.ErrorResponse
 // @Router /strikes [post]
 func CreateStrikeHandler(c *gin.Context) {
 	role := c.GetString("role")
@@ -47,9 +47,9 @@ func CreateStrikeHandler(c *gin.Context) {
 // @Produce json
 // @Param id path int true "ID do cliente"
 // @Success 200 {array} dto.StrikeOutputDTO
-// @Failure 400 {object} gin.H
-// @Failure 403 {object} gin.H
-// @Failure 500 {object} gin.H
+// @Failure 400 {object} dto.ErrorResponse
+// @Failure 403 {object} dto.ErrorResponse
+// @Failure 500 {object} dto.ErrorResponse
 // @Router /strikes/client/{id} [get]
 func GetStrikesByClientHandler(c *gin.Context) {
 	role := c.GetString("role")
@@ -77,9 +77,9 @@ func GetStrikesByClientHandler(c *gin.Context) {
 // @Tags strikes
 // @Param id path int true "ID do strike"
 // @Success 200 {object} dto.StrikeOutputDTO
-// @Failure 400 {object} gin.H
-// @Failure 403 {object} gin.H
-// @Failure 500 {object} gin.H
+// @Failure 400 {object} dto.ErrorResponse
+// @Failure 403 {object} dto.ErrorResponse
+// @Failure 500 {object} dto.ErrorResponse
 // @Router /strikes/{id} [delete]
 func RevokeStrikeHandler(c *gin.Context) {
 	role := c.GetString("role")

--- a/handlers/user_handlers.go
+++ b/handlers/user_handlers.go
@@ -15,8 +15,8 @@ import (
 // @Tags usuarios
 // @Produce json
 // @Success 200 {array} dto.UserOutputDTO
-// @Failure 403 {object} gin.H
-// @Failure 500 {object} gin.H
+// @Failure 403 {object} dto.ErrorResponse
+// @Failure 500 {object} dto.ErrorResponse
 // @Router /users [get]
 func GetAllUsersHandler(c *gin.Context) {
 	role := c.GetString("role")
@@ -39,8 +39,8 @@ func GetAllUsersHandler(c *gin.Context) {
 // @Produce json
 // @Param id path int true "ID do usuário"
 // @Success 200 {object} dto.UserOutputDTO
-// @Failure 403 {object} gin.H
-// @Failure 404 {object} gin.H
+// @Failure 403 {object} dto.ErrorResponse
+// @Failure 404 {object} dto.ErrorResponse
 // @Router /users/{id} [get]
 func GetUserByIDHandler(c *gin.Context) {
 	role := c.GetString("role")
@@ -70,9 +70,9 @@ func GetUserByIDHandler(c *gin.Context) {
 // @Produce json
 // @Param input body dto.UserInputDTO true "Dados do usuário"
 // @Success 201 {object} dto.UserOutputDTO
-// @Failure 400 {object} gin.H
-// @Failure 403 {object} gin.H
-// @Failure 500 {object} gin.H
+// @Failure 400 {object} dto.ErrorResponse
+// @Failure 403 {object} dto.ErrorResponse
+// @Failure 500 {object} dto.ErrorResponse
 // @Router /users [post]
 func CreateUserHandler(c *gin.Context) {
 	role := c.GetString("role")
@@ -99,8 +99,8 @@ func CreateUserHandler(c *gin.Context) {
 // @Tags usuarios
 // @Param id path int true "ID do usuário"
 // @Success 204 {object} nil
-// @Failure 403 {object} gin.H
-// @Failure 500 {object} gin.H
+// @Failure 403 {object} dto.ErrorResponse
+// @Failure 500 {object} dto.ErrorResponse
 // @Router /users/{id} [delete]
 func DeleteUserHandler(c *gin.Context) {
 	role := c.GetString("role")
@@ -128,7 +128,7 @@ func DeleteUserHandler(c *gin.Context) {
 // @Tags usuarios
 // @Produce json
 // @Success 200 {object} dto.UserOutputDTO
-// @Failure 401 {object} gin.H
+// @Failure 401 {object} dto.ErrorResponse
 // @Router /users/me [get]
 func MeHandler(c *gin.Context) {
 	userIDInterface, exists := c.Get("userID")


### PR DESCRIPTION
## Summary
- add ErrorResponse and MessageResponse DTOs
- document handler failures with ErrorResponse instead of gin.H
- use MessageResponse for simple success responses in space handlers

## Testing
- `go test ./...` *(fails: missing go.sum entries)*
- `swag init` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab87ab6bec8324b0131ef40fc19982