### PR TITLE
docs: add setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,46 @@
 # reservas-cipt
-Backend do sistema de reservas do CIPT Jaraguá
+
+Backend do sistema de reservas do CIPT Jaraguá.
+
+## Requisitos
+
+- [Go](https://go.dev/) 1.20+
+- [Docker](https://www.docker.com/) e Docker Compose (opcional, para o banco de dados)
+
+## Configuração
+
+1. Crie um arquivo `.env` na raiz do projeto com as variáveis abaixo:
+
+   ```env
+   DB_HOST=localhost
+   DB_PORT=5432
+   DB_USER=postgres
+   DB_PASSWORD=postgres
+   DB_NAME=reservas
+   DB_SSLMODE=disable
+   JWT_SECRET=sua_chave_segura
+   ```
+
+2. (Opcional) Inicie um banco PostgreSQL via Docker:
+
+   ```bash
+   docker-compose up -d db
+   ```
+
+3. Execute a API:
+
+   ```bash
+   go run main.go
+   ```
+
+   O serviço estará disponível em `http://localhost:8080`.
+
+## Testes
+
+Para rodar os testes dos services e handlers:
+
+```bash
+go test ./tests/services ./tests/handlers
+```
+
+Os testes usam um banco SQLite em memória e não dependem do PostgreSQL.


### PR DESCRIPTION
## Summary
- document project setup and test instructions

## Testing
- `go test ./tests/services ./tests/handlers` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8c62a20483248730c8a0681ca535